### PR TITLE
Add (error) to catch block

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,32 +1,35 @@
 #!/usr/bin/env node
 
-const path = require('path');
-const git = require('simple-git')();
-const shell = require('shelljs')
-const tmp = require('tmp');
-const command = require('commander');
-const fs = require('fs');
-const pkg = require('./package.json');
-const inquirer = require('inquirer');
+const path = require("path");
+const git = require("simple-git")();
+const shell = require("shelljs");
+const tmp = require("tmp");
+const command = require("commander");
+const fs = require("fs");
+const pkg = require("./package.json");
+const inquirer = require("inquirer");
 
 let name;
-const templateRepo = 'https://github.com/JBKLabs/example-react-project';
+const templateRepo = "https://github.com/JBKLabs/example-react-project";
 
-const run = (message, cb) => (...args) => new Promise(async (resolve) => {
-  console.log(`${message} ...`);
-  cb(...args, (result) => {
-    console.log('\tdone.');
-    resolve(result);
+const run = (message, cb) => (...args) =>
+  new Promise(async resolve => {
+    console.log(`${message} ...`);
+    cb(...args, result => {
+      console.log("\tdone.");
+      resolve(result);
+    });
   });
-}); 
 
-const createProjectDirectory = (name) => {
-  if (name !== '.') {
+const createProjectDirectory = name => {
+  if (name !== ".") {
     try {
       fs.mkdirSync(name);
     } catch (error) {
-      if (error.code === 'EEXIST') {
-        throw new Error(`That directory already exists. Try running from within ${name}/ as 'create-react-app .'`);
+      if (error.code === "EEXIST") {
+        throw new Error(
+          `That directory already exists. Try running from within ${name}/ as 'create-react-app .'`
+        );
       } else {
         throw error;
       }
@@ -34,7 +37,7 @@ const createProjectDirectory = (name) => {
   }
 };
 
-const cloneExampleProject = run('cloning example project', (cb) => {
+const cloneExampleProject = run("cloning example project", cb => {
   tmp.dir({ unsafeCleanup: true }, (err, tmpPath, cleanupCallback) => {
     if (err) {
       throw err;
@@ -46,7 +49,7 @@ const cloneExampleProject = run('cloning example project', (cb) => {
       const result = {
         path: tmpPath,
         clear: cleanupCallback
-      }
+      };
 
       if (branchName) {
         git.cwd(tmpPath).checkout(branchName, () => {
@@ -62,67 +65,80 @@ const cloneExampleProject = run('cloning example project', (cb) => {
 
 const replaceToken = (tempPath, [key, value]) => {
   if (key && value) {
-    shell.ls('-RA', `${tempPath}`).forEach((file) => {
+    shell.ls("-RA", `${tempPath}`).forEach(file => {
       try {
-        shell.sed('-i',`<% ${key} %>`, value.toString(), path.join(tempPath, file));
-      } catch {}
+        shell.sed(
+          "-i",
+          `<% ${key} %>`,
+          value.toString(),
+          path.join(tempPath, file)
+        );
+      } catch (_) {}
     });
   }
-}
+};
 
-const renderTemplate = run('rendering template', (template, projectPath, options, cb) => {
-  shell.rm('-rf', path.join(template.path, './.git'));
-  Object.entries(options).forEach(o => replaceToken(template.path, o));
-  shell.cp('-rf', `${template.path}/*`, projectPath);
-  shell.cp('-rf', `${template.path}/.*`, projectPath);
-  template.clear();
-  cb();
-});
+const renderTemplate = run(
+  "rendering template",
+  (template, projectPath, options, cb) => {
+    shell.rm("-rf", path.join(template.path, "./.git"));
+    Object.entries(options).forEach(o => replaceToken(template.path, o));
+    shell.cp("-rf", `${template.path}/*`, projectPath);
+    shell.cp("-rf", `${template.path}/.*`, projectPath);
+    template.clear();
+    cb();
+  }
+);
 
-const prepareProject = run('preparing project', (projectPath, options, cb) => {
+const prepareProject = run("preparing project", (projectPath, options, cb) => {
   shell.cd(projectPath);
 
-  if (options.initializeGit && shell.exec('git init').code !== 0) {
-    shell.echo('Error: git init failed');
+  if (options.initializeGit && shell.exec("git init").code !== 0) {
+    shell.echo("Error: git init failed");
     shell.exit(1);
   }
 
-  console.log('installing dependencies ...')
+  console.log("installing dependencies ...");
 
-  if (shell.exec('npm i').code !== 0) {
-    shell.echo('Error: npm install failed');
+  if (shell.exec("npm i").code !== 0) {
+    shell.echo("Error: npm install failed");
     shell.exit(1);
   }
 
   cb();
 });
 
-const promptUser = (projectPath) => new Promise((resolve) => {
-  const gitPrompt = !fs.existsSync(`${projectPath}/.git`)
-    ? [{
-      type: 'confirm',
-      message: 'Would you like to initialize git?',
-      name: 'initializeGit'
-    }] : [];
+const promptUser = projectPath =>
+  new Promise(resolve => {
+    const gitPrompt = !fs.existsSync(`${projectPath}/.git`)
+      ? [
+          {
+            type: "confirm",
+            message: "Would you like to initialize git?",
+            name: "initializeGit"
+          }
+        ]
+      : [];
 
-  inquirer.prompt([
-    { 
-      type: "input",
-      message: "Enter your project name:",
-      name: "projectName"
-    },
-    ...gitPrompt
-  ])
-  .then(resolve);
-})
+    inquirer
+      .prompt([
+        {
+          type: "input",
+          message: "Enter your project name:",
+          name: "projectName"
+        },
+        ...gitPrompt
+      ])
+      .then(resolve);
+  });
 
 command
   .version(pkg.version)
-  .arguments('<directoryName>')
-  .option('-b, --branch [branch]', 'example-react-project branch name')
-  .action(async (directoryName) => {
+  .arguments("<directoryName>")
+  .option("-b, --branch [branch]", "example-react-project branch name")
+  .action(async directoryName => {
     name = directoryName;
-    const projectPath = name ? `./${name}` : '.';
+    const projectPath = name ? `./${name}` : ".";
     createProjectDirectory(name);
     const options = await promptUser(projectPath);
     const template = await cloneExampleProject();
@@ -132,7 +148,7 @@ command
 
 command.parse(process.argv);
 
-if(typeof name === 'undefined') {
-  console.error('Directory name is required.');
+if (typeof name === "undefined") {
+  console.error("Directory name is required.");
   process.exit(1);
 }


### PR DESCRIPTION
Closes #6 

## Changes

- Add `(error)` to `catch` block

## Steps to Test

This has been tested on Mac and appears to be working. To double check:
- [x] `npm link`
- [x] `create-react-app test`